### PR TITLE
Add support for contextName

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,5 @@ install:
 - chmod +x ./kubectl
 - sudo mv ./kubectl /usr/local/bin/kubectl
 
-
 after_success:
 - mvn clean test jacoco:report coveralls:report

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
@@ -46,6 +46,9 @@ public class KubectlBuildStep extends Step {
     @DataBoundSetter
     public String caCertificate;
 
+    @DataBoundSetter
+    public String contextName;
+
     @DataBoundConstructor
     public KubectlBuildStep() {
     }
@@ -74,6 +77,7 @@ public class KubectlBuildStep extends Step {
                     step.serverUrl,
                     step.credentialsId,
                     step.caCertificate,
+                    step.contextName,
                     getContext());
 
             // Write config

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper.java
@@ -45,6 +45,9 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
     @DataBoundSetter
     public String caCertificate;
 
+    @DataBoundSetter
+    public String contextName;
+
     @DataBoundConstructor
     public KubectlBuildWrapper() {
     }
@@ -59,6 +62,7 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
                 this.serverUrl,
                 this.credentialsId,
                 this.caCertificate,
+                this.contextName,
                 workspace,
                 launcher,
                 build);

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
@@ -77,7 +77,9 @@ public class KubeConfigWriter {
             if (wasContextProvided()) {
                 useContext(configFile.getRemote(), this.contextName);
             }
-            //Log warning if server rprovided
+            if(this.wasServerUrlProvided()){
+                launcher.getListener().getLogger().println("the serverUrl will be ignored as a raw kubeconfig file was provided");
+            }
         } else {
             setCluster(configFile.getRemote());
             setCredentials(configFile.getRemote(), credentials);
@@ -260,12 +262,21 @@ public class KubeConfigWriter {
     }
 
     /**
-     * Return whether or not a contexName was provided
+     * Return whether or not a contextName was provided
      *
      * @return true if a contextName was provided to the plugin.
      */
     private boolean wasContextProvided() {
         return this.contextName != null && !this.contextName.isEmpty();
+    }
+
+    /**
+     * Return whether or not a serverUrl was provided
+     *
+     * @return true if a serverUrl was provided to the plugin.
+     */
+    private boolean wasServerUrlProvided() {
+        return this.serverUrl != null && !this.serverUrl.isEmpty();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
@@ -78,7 +78,7 @@ public class KubeConfigWriter {
             if (wasContextProvided()) {
                 useContext(configFile.getRemote(), this.contextName);
             }
-            if(this.wasServerUrlProvided()){
+            if (this.wasServerUrlProvided()) {
                 launcher.getListener().getLogger().println("the serverUrl will be ignored as a raw kubeconfig file was provided");
             }
         } else {
@@ -99,9 +99,9 @@ public class KubeConfigWriter {
      * @throws InterruptedException on file operations
      */
     private void setRawKubeConfig(FilePath configFile, FileCredentials credentials) throws IOException, InterruptedException {
-        OutputStream output = configFile.write();
-        IOUtils.copy(credentials.getContent(), output);
-        output.close();
+        try (OutputStream output = configFile.write()) {
+            IOUtils.copy(credentials.getContent(), output);
+        }
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
@@ -70,7 +70,9 @@ public class KubeConfigWriter {
         FilePath configFile = workspace.createTempFile(".kube", "config");
 
         final StandardCredentials credentials = getCredentials(build);
-        if (credentials instanceof FileCredentials) {
+        if (credentials == null) {
+            throw new AbortException("No credentials defined to setup Kubernetes CLI");
+        } else if (credentials instanceof FileCredentials) {
             setRawKubeConfig(configFile, (FileCredentials) credentials);
             if (wasContextProvided()) {
                 useContext(configFile.getRemote(), this.contextName);
@@ -147,9 +149,7 @@ public class KubeConfigWriter {
 
         String credentialsArgs;
         int sensitiveFieldsCount = 1;
-        if (credentials == null) {
-            throw new AbortException("No credentials defined to setup Kubernetes CLI");
-        } else if (credentials instanceof TokenProducer) {
+        if (credentials instanceof TokenProducer) {
             credentialsArgs = "--token=\"" + ((TokenProducer) credentials).getToken(serverUrl, null, true) + "\"";
         } else if (credentials instanceof StringCredentials) {
             credentialsArgs = "--token=\"" + ((StringCredentials) credentials).getSecret() + "\"";

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
@@ -19,6 +19,7 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Collections;
 import java.util.Set;
 
@@ -98,7 +99,9 @@ public class KubeConfigWriter {
      * @throws InterruptedException on file operations
      */
     private void setRawKubeConfig(FilePath configFile, FileCredentials credentials) throws IOException, InterruptedException {
-        IOUtils.copy(credentials.getContent(), configFile.write());
+        OutputStream output = configFile.write();
+        IOUtils.copy(credentials.getContent(), output);
+        output.close();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterFactory.java
@@ -13,15 +13,15 @@ import java.io.IOException;
  */
 public abstract class KubeConfigWriterFactory {
     public static KubeConfigWriter get(@Nonnull String serverUrl, @Nonnull String credentialsId,
-                                       @Nonnull String caCertificate, FilePath workspace, Launcher launcher, Run<?, ?> build) {
-        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, workspace, launcher, build);
+                                       @Nonnull String caCertificate, @Nonnull String contextName, FilePath workspace, Launcher launcher, Run<?, ?> build) {
+        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, contextName, workspace, launcher, build);
     }
 
     public static KubeConfigWriter get(@Nonnull String serverUrl, @Nonnull String credentialsId,
-                                       @Nonnull String caCertificate, StepContext context) throws IOException, InterruptedException {
+                                       @Nonnull String caCertificate, @Nonnull String contextName, StepContext context) throws IOException, InterruptedException {
         Run<?, ?> run = context.get(Run.class);
         FilePath workspace = context.get(FilePath.class);
         Launcher launcher = context.get(Launcher.class);
-        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, workspace, launcher, run);
+        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, contextName, workspace, launcher, run);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStepTest.java
@@ -143,4 +143,16 @@ public class KubectlBuildStepTest extends KubectlTestBase {
         r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b));
         r.assertLogContains("ERROR: Uninitialized keystore", b);
     }
+
+    @Test
+    public void testServerProvidedWithFileCredential() throws Exception {
+        CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), fileCredential(CREDENTIAL_ID));
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "testWithFileCertificateAndServer");
+        p.setDefinition(new CpsFlowDefinition(loadResource("mockedKubectl.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(b));
+        r.assertLogContains("the serverUrl will be ignored as a raw kubeconfig file was provided", b);
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStepTest.java
@@ -86,11 +86,11 @@ public class KubectlBuildStepTest extends KubectlTestBase {
     public void testKubeConfigDisposed() throws Exception {
         CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), usernamePasswordCredentialWithSpace(CREDENTIAL_ID));
 
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "testUsernamePasswordWithSpace");
-        p.setDefinition(new CpsFlowDefinition(loadResource("mockedKubectl.groovy"), true));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "testCleanupOnFailure");
+        p.setDefinition(new CpsFlowDefinition(loadResource("mockedKubectlFailure.groovy"), true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         assertNotNull(b);
-        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b));
         r.assertLogContains("kubectl configuration cleaned up", b);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlTestBase.java
@@ -108,11 +108,22 @@ public class KubectlTestBase {
         return new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialId, "sample", USERNAME_WITH_SPACE, PASSWORD_WITH_SPACE);
     }
 
-    protected FileCredentials fileCredential(String credentialId) throws UnsupportedEncodingException {
-        return new FileCredentialsImpl(CredentialsScope.GLOBAL, credentialId, "sample", "file-name", SecretBytes.fromBytes("---\napiVersion: v1\nclusters:\n- cluster:\n  name: test-sample\n".getBytes("UTF-8")));
-    }
-
     protected OpenShiftBearerTokenCredentialImpl tokenCredential(String credentialId) {
         return new OpenShiftBearerTokenCredentialImpl(CredentialsScope.GLOBAL, credentialId, "a-description", USERNAME, PASSWORD);
+    }
+
+    protected FileCredentials fileCredential(String credentialId) throws UnsupportedEncodingException {
+        return new FileCredentialsImpl(CredentialsScope.GLOBAL,
+                credentialId,
+                "sample",
+                "file-name",
+                SecretBytes.fromBytes(("---\n" +
+                        "apiVersion: v1\n" +
+                        "contexts:\n" +
+                        "- context:\n" +
+                        "  name: test-sample\n" +
+                        "- context:\n" +
+                        "  name: k8s\n" +
+                        "current-context: minikube\n").getBytes("UTF-8")));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlTestBase.java
@@ -8,7 +8,8 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.model.Slave;
 import hudson.util.Secret;
 import org.apache.commons.compress.utils.IOUtils;
-import org.jenkinsci.plugins.kubernetes.credentials.OpenShiftBearerTokenCredentialImpl;
+import org.jenkinsci.plugins.kubernetes.cli.utils.FakeBearerTokenCredentialImpl;
+import org.jenkinsci.plugins.kubernetes.cli.utils.UnsupportedCredential;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
@@ -108,10 +109,6 @@ public class KubectlTestBase {
         return new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialId, "sample", USERNAME_WITH_SPACE, PASSWORD_WITH_SPACE);
     }
 
-    protected OpenShiftBearerTokenCredentialImpl tokenCredential(String credentialId) {
-        return new OpenShiftBearerTokenCredentialImpl(CredentialsScope.GLOBAL, credentialId, "a-description", USERNAME, PASSWORD);
-    }
-
     protected FileCredentials fileCredential(String credentialId) throws UnsupportedEncodingException {
         return new FileCredentialsImpl(CredentialsScope.GLOBAL,
                 credentialId,
@@ -125,5 +122,13 @@ public class KubectlTestBase {
                         "- context:\n" +
                         "  name: k8s\n" +
                         "current-context: minikube\n").getBytes("UTF-8")));
+    }
+
+    protected FakeBearerTokenCredentialImpl tokenCredential(String credentialId) {
+        return new FakeBearerTokenCredentialImpl(CredentialsScope.GLOBAL, credentialId, "a-description", USERNAME, PASSWORD);
+    }
+
+    protected UnsupportedCredential unsupportedCredential(String credentialId) {
+        return new UnsupportedCredential(credentialId, "sample");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlTestBase.java
@@ -101,6 +101,12 @@ public class KubectlTestBase {
         return new CertificateCredentialsImpl(CredentialsScope.GLOBAL, credentialId, "sample", PASSPHRASE, keyStoreSource);
     }
 
+    protected BaseStandardCredentials brokenCertificateCredential(String credentialId) {
+        String storeFile = getResourceFile("/org/jenkinsci/plugins/kubernetes/cli/kubernetes.pkcs12");
+        CertificateCredentialsImpl.KeyStoreSource keyStoreSource = new CertificateCredentialsImpl.FileOnMasterKeyStoreSource(storeFile);
+        return new CertificateCredentialsImpl(CredentialsScope.GLOBAL, credentialId, "sample", "bad-passphrase", keyStoreSource);
+    }
+
     protected BaseStandardCredentials usernamePasswordCredential(String credentialId) {
         return new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialId, "sample", USERNAME, PASSWORD);
     }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/utils/FakeBearerTokenCredentialImpl.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/utils/FakeBearerTokenCredentialImpl.java
@@ -1,0 +1,20 @@
+package org.jenkinsci.plugins.kubernetes.cli.utils;
+
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import org.jenkinsci.plugins.kubernetes.credentials.TokenProducer;
+
+import java.io.IOException;
+
+public class FakeBearerTokenCredentialImpl extends UsernamePasswordCredentialsImpl implements TokenProducer {
+
+    public FakeBearerTokenCredentialImpl(CredentialsScope scope, String id, String description, String username, String password) {
+        super(scope, id, description, username, password);
+    }
+
+    @Override
+    public String getToken(String serviceAddress, String caCertData, boolean skipTlsVerify) throws IOException {
+        return "faketoken:" + this.getUsername() + ":" + this.getPassword();
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/utils/UnsupportedCredential.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/utils/UnsupportedCredential.java
@@ -1,0 +1,10 @@
+package org.jenkinsci.plugins.kubernetes.cli.utils;
+
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+
+public class UnsupportedCredential extends BaseStandardCredentials {
+
+    public UnsupportedCredential(String id, String description) {
+        super(id, description);
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/kubectlRawWithContext.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/kubectlRawWithContext.groovy
@@ -1,0 +1,7 @@
+node{
+  stage('Run') {
+    withKubeConfig([credentialsId: 'cred1234', contextName: 'test-sample']) {
+      sh 'cat "$KUBECONFIG" > configDump'
+    }
+  }
+}

--- a/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/kubectlWithoutCaWithContext.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/kubectlWithoutCaWithContext.groovy
@@ -1,0 +1,7 @@
+node{
+  stage('Run') {
+    withKubeConfig([credentialsId: 'cred1234', serverUrl: 'https://localhost:6443', contextName: 'test-sample']) {
+      sh 'cat "$KUBECONFIG" > configDump'
+    }
+  }
+}

--- a/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/mockedKubectlFailure.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/mockedKubectlFailure.groovy
@@ -1,0 +1,8 @@
+node{
+  label "mocked-kubectl"
+  stage('Run') {
+    withKubeConfig([credentialsId: 'cred1234', serverUrl: 'https://localhost:6443']) {
+      error("Build failed because of this and that..")
+    }
+  }
+}

--- a/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/mockedKubectlWithEmptyCredential.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/mockedKubectlWithEmptyCredential.groovy
@@ -1,0 +1,8 @@
+node{
+  label "mocked-kubectl"
+  stage('Run') {
+    withKubeConfig([credentialsId: '', serverUrl: 'https://localhost:6443']) {
+      echo "File has been configured '${env.KUBECONFIG}'"
+    }
+  }
+}


### PR DESCRIPTION
Allow to specify the context to be used to configure `kubectl`