### PR TITLE
Depend on apache-httpcomponent plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.6</version>
+    <version>3.20</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -34,8 +34,8 @@
     <java.level>8</java.level>
 
     <!-- dependency versions -->
-    <httpclient.version>4.5.1</httpclient.version>
-    <jenkins.version>2.32.1</jenkins.version>
+    <httpclient.version>4.5.5-3.0</httpclient.version>
+    <jenkins.version>2.60.3</jenkins.version>
     <slf4j.version>1.7.25</slf4j.version>
 
     <!-- jenkins plugins versions -->
@@ -57,8 +57,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
       <version>${httpclient.version}</version>
     </dependency>
 


### PR DESCRIPTION
* Update parent POM
* Bump required core to 2.60.3 (already 1 year old)
* Replace dependency to httpclient lib by the corresponding library
plugin