### PR TITLE
added support for clusterName option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ node {
     withKubeConfig([credentialsId: '<credential-id>',
                     caCertificate: '<ca-certificate>',
                     serverUrl: '<api-server-address>',
-                    contextName: '<context-name>'
+                    contextName: '<context-name>',
+                    clusterName: '<cluster-name>'
                     ]) {
       sh 'kubectl get pods'
     }
@@ -49,6 +50,7 @@ The arguments to the `withKubeConfig` step are:
 * `caCertificate` - an optional certificate to check the Kubernetes api server's against. If you don't specify one, the CA verification will be skipped.
 * `serverUrl` - the url of the api server
 * `contextName` - name of the context to create or to switch to if a raw kubeconfig was provided
+* `clusterName` - name of the cluster to create or to switch to if a raw kubeconfig was provided
 
 
 ### From the web interface
@@ -65,6 +67,7 @@ Brief description of the named fields:
 * **caCertificate** - an optional certificate to check the Kubernetes api server's against
 * **serverUrl** - the url of the api server
 * **contextName** - name of the context to create or to switch to if a raw kubeconfig was provided
+* **clusterName** - name of the cluster to create or to switch to if a raw kubeconfig was provided
 
 
 ## Reporting an issue

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>kubernetes-cli</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.3.2-SNAPSHOT</version>
   <name>Kubernetes Cli Plugin</name>
   <description>Configure kubectl for Kubernetes</description>
   <packaging>hpi</packaging>

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
@@ -49,6 +49,9 @@ public class KubectlBuildStep extends Step {
     @DataBoundSetter
     public String contextName;
 
+    @DataBoundSetter
+    public String clusterName;
+    
     @DataBoundConstructor
     public KubectlBuildStep() {
     }
@@ -77,6 +80,7 @@ public class KubectlBuildStep extends Step {
                     step.serverUrl,
                     step.credentialsId,
                     step.caCertificate,
+                    step.clusterName,
                     step.contextName,
                     getContext());
 

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper.java
@@ -47,6 +47,9 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
 
     @DataBoundSetter
     public String contextName;
+    
+    @DataBoundSetter
+    public String clusterName;
 
     @DataBoundConstructor
     public KubectlBuildWrapper() {
@@ -62,6 +65,7 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
                 this.serverUrl,
                 this.credentialsId,
                 this.caCertificate,
+                this.clusterName,
                 this.contextName,
                 workspace,
                 launcher,

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterFactory.java
@@ -13,15 +13,15 @@ import java.io.IOException;
  */
 public abstract class KubeConfigWriterFactory {
     public static KubeConfigWriter get(@Nonnull String serverUrl, @Nonnull String credentialsId,
-                                       String caCertificate, String contextName, FilePath workspace, Launcher launcher, Run<?, ?> build) {
-        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, contextName, workspace, launcher, build);
+                                       String caCertificate, String clusterName, String contextName, FilePath workspace, Launcher launcher, Run<?, ?> build) {
+        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, clusterName, contextName, workspace, launcher, build);
     }
 
     public static KubeConfigWriter get(@Nonnull String serverUrl, @Nonnull String credentialsId,
-                                       String caCertificate, String contextName, StepContext context) throws IOException, InterruptedException {
+                                       String caCertificate, String clusterName, String contextName, StepContext context) throws IOException, InterruptedException {
         Run<?, ?> run = context.get(Run.class);
         FilePath workspace = context.get(FilePath.class);
         Launcher launcher = context.get(Launcher.class);
-        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, contextName, workspace, launcher, run);
+        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, clusterName, contextName, workspace, launcher, run);
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep/config.jelly
@@ -13,6 +13,10 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry field="clusterName" title="${%Cluster name}">
+    <f:textbox/>
+  </f:entry>
+
   <f:entry title="${%Certificate of certificate authority (CA)}" field="caCertificate">
     <f:textarea/>
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper/config.jelly
@@ -13,6 +13,10 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry field="clusterName" title="${%Cluster name}">
+    <f:textbox/>
+  </f:entry>
+
   <f:entry title="${%Certificate of certificate authority (CA)}" field="caCertificate">
     <f:textarea/>
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper/help-clusterName.html
+++ b/src/main/resources/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper/help-clusterName.html
@@ -1,0 +1,3 @@
+<div>
+    Cluster name to use or to switch to.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlTestBase.java
@@ -38,6 +38,7 @@ public class KubectlTestBase {
     protected static final String PASSWORD_WITH_SPACE = "s3cr3t with-passwordspace";
     protected static final String CA_CERTIFICATE = "-----BEGIN CERTIFICATE-----\na-certificate\n-----END CERTIFICATE-----";
     protected static final String SERVER_URL = "https://localhost:6443";
+    protected static final String CLUSTER_NAME = "test-cluster";
     protected static final String KUBECTL_BINARY = "kubectl";
 
     protected String loadResource(String name) {

--- a/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/kubectlRawWithCluster.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/kubectlRawWithCluster.groovy
@@ -1,0 +1,7 @@
+node{
+  stage('Run') {
+    withKubeConfig([credentialsId: 'cred1234', clusterName: 'test-cluster']) {
+      sh 'cat "$KUBECONFIG" > configDump'
+    }
+  }
+}


### PR DESCRIPTION
The `--cluster` option is hard coded and can't be configured. This patch adds the `clusterName` parameter in pipelines.