### PR TITLE
Update credentials plugin from 2.1.7 to 2.1.19 (2.2.0) CVE-2019-10320

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <jenkins-credentials.version>2.1.19</jenkins-credentials.version>
     <jenkins-env-inject.version>2.1.3</jenkins-env-inject.version>
     <jenkins-plain-credentials.version>1.3</jenkins-plain-credentials.version>
-    <jenkins-structs.version>1.6</jenkins-structs.version>
+    <jenkins-structs.version>1.19</jenkins-structs.version>
     <jenkins-workflow-cps.version>2.29</jenkins-workflow-cps.version>
     <jenkins-workflow-step-api.version>2.11</jenkins-workflow-step-api.version>
     <jenkins-workflow-support.version>2.14</jenkins-workflow-support.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <slf4j.version>1.7.25</slf4j.version>
 
     <!-- jenkins plugins versions -->
-    <jenkins-credentials.version>2.1.7</jenkins-credentials.version>
+    <jenkins-credentials.version>2.1.19</jenkins-credentials.version>
     <jenkins-env-inject.version>2.1.3</jenkins-env-inject.version>
     <jenkins-plain-credentials.version>1.3</jenkins-plain-credentials.version>
     <jenkins-structs.version>1.6</jenkins-structs.version>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-10320
https://github.com/jenkinsci/credentials-plugin/releases

https://plugins.jenkins.io/credentials
https://wiki.jenkins.io/display/JENKINS/Credentials+Plugin