### PR TITLE
non-default namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ kubectl -n <namespace> create serviceaccount jenkins-robot
 # The next line gives `jenkins-robot` administator permissions for this namespace.
 # * You can make it an admin over all namespaces by creating a `ClusterRoleBinding` instead of a `RoleBinding`.
 # * You can also give it different permissions by binding it to a different `(Cluster)Role`.
-$ kubectl -n <namespace> create rolebinding jenkins-robot-binding --clusterrole=cluster-admin --serviceaccount=jenkins-robot
+$ kubectl -n <namespace> create rolebinding jenkins-robot-binding --clusterrole=cluster-admin --serviceaccount=<namespace>:jenkins-robot
 
 # Get the name of the token that was automatically generated for the ServiceAccount `jenkins-robot`.
 $ kubectl -n <namespace> get serviceaccount jenkins-robot -o go-template --template='{{range .secrets}}{{.name}}{{"\n"}}{{end}}'


### PR DESCRIPTION
namespace of the service account is required if it is not the 'default' namespace.