### PR TITLE
Fix escaping of certificate-authority parameter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
@@ -145,17 +145,19 @@ public class KubeConfigWriter {
             caCrtFile.write(CertificateHelper.wrapCertificate(caCertificate), null);
             filesToBeRemoved.add(caCrtFile.getRemote());
 
-            tlsConfigArgs = " --embed-certs=true --certificate-authority=" + caCrtFile.getRemote();
+            tlsConfigArgs = " --embed-certs=true --certificate-authority=\"" + caCrtFile.getRemote()+"\"";
         }
 
         try {
+            String[] cmds = QuotedStringTokenizer.tokenize(String.format("%s config set-cluster %s --server=%s %s",
+                    KUBECTL_BINARY,
+                    getClusterNameOrDefault(),
+                    getServerUrl(),
+                    tlsConfigArgs));
+
             int status = launcher.launch()
                     .envs(String.format("KUBECONFIG=%s", configFile))
-                    .cmdAsSingleString(String.format("%s config set-cluster %s --server=%s %s",
-                            KUBECTL_BINARY,
-                            getClusterNameOrDefault(),
-                            getServerUrl(),
-                            tlsConfigArgs))
+                    .cmds(cmds)
                     .stdout(launcher.getListener())
                     .join();
             if (status != 0) throw new IOException("Failed to add kubectl cluster (exit code  " + status + ")");


### PR DESCRIPTION
If the Jenkins workspace contains spaces, the path to the temporary files containing certificates have to be escaped when passed as parameter to a `kubectl` call.