### PR TITLE
remove duplicated KubeConfigExpander

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubeConfigExpander.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubeConfigExpander.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.kubernetes.cli;
 
 import hudson.EnvVars;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
-
+import org.jenkinsci.plugins.kubernetes.cli.kubeconfig.KubeConfigWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -13,13 +13,12 @@ import java.util.Map;
 final class KubeConfigExpander extends EnvironmentExpander {
 
     private static final long serialVersionUID = 1;
-    private static final String KUBECONFIG = "KUBECONFIG";
 
     private final Map<String, String> overrides;
 
     KubeConfigExpander(String path) {
         this.overrides = new HashMap<>();
-        this.overrides.put(KUBECONFIG, path);
+        this.overrides.put(KubeConfigWriter.ENV_VARIABLE_NAME, path);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
@@ -183,18 +183,4 @@ public class KubectlBuildStep extends Step {
         }
     }
 
-    static final class KubeConfigExpander extends EnvironmentExpander {
-
-        private final Map<String, String> envOverride;
-
-        KubeConfigExpander(String kubeConfigPath) {
-            this.envOverride = new HashMap<>();
-            this.envOverride.put(KubeConfigWriter.ENV_VARIABLE_NAME, kubeConfigPath);
-        }
-
-        @Override
-        public void expand(EnvVars env) throws IOException, InterruptedException {
-            env.overrideAll(envOverride);
-        }
-    }
 }


### PR DESCRIPTION
Did not test this, but it made sense to do the cleanup outside of the multi-kube-config patch.