### PR TITLE
Add support for new kubectl versions and drop olders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ cache:
   - $HOME/.m2
 
 env:
+  - KUBECTL_VERSION=v1.17.0
+  - KUBECTL_VERSION=v1.16.4
   - KUBECTL_VERSION=v1.15.1
   - KUBECTL_VERSION=v1.14.3
   - KUBECTL_VERSION=v1.13.3
   - KUBECTL_VERSION=v1.12.9
-  - KUBECTL_VERSION=v1.11.10
-  - KUBECTL_VERSION=v1.10.13
 
 install:
 - curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ node {
 
 ## Prerequisites
 * A jenkins installation running version 2.60.3 or higher.
-* An executor with `kubectl` installed (tested against [v1.10 to v1.15][travis-config] included).
+* An executor with `kubectl` installed (tested against [v1.12 to v1.17][travis-config] included).
 * A Kubernetes cluster.
 
 ## Supported credentials

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlIntegrationTest.java
@@ -269,7 +269,7 @@ public class KubectlIntegrationTest extends KubectlTestBase {
         assertTrue(configDump.exists());
         String configDumpContent = configDump.readToString().trim();
 
-        assertEquals("apiVersion: v1\n" +
+        assertThat(configDumpContent, containsString("apiVersion: v1\n" +
                 "clusters:\n" +
                 "- cluster:\n" +
                 "    server: \"\"\n" +
@@ -290,10 +290,7 @@ public class KubectlIntegrationTest extends KubectlTestBase {
                 "    cluster: test-sample\n" +
                 "    user: \"\"\n" +
                 "  name: test-sample\n" +
-                "current-context: test-sample\n" +
-                "kind: Config\n" +
-                "preferences: {}\n" +
-                "users: []", configDumpContent);
+                "current-context: test-sample\n"));
     }
 
     @Test
@@ -359,7 +356,7 @@ public class KubectlIntegrationTest extends KubectlTestBase {
         assertTrue(configDump.exists());
         String configDumpContent = configDump.readToString().trim();
 
-        assertEquals("apiVersion: v1\n" +
+        assertThat(configDumpContent, containsString("apiVersion: v1\n" +
                 "clusters:\n" +
                 "- cluster:\n" +
                 "    insecure-skip-tls-verify: true\n" +
@@ -385,10 +382,7 @@ public class KubectlIntegrationTest extends KubectlTestBase {
                 "    cluster: cred1234\n" +
                 "    user: \"\"\n" +
                 "  name: test-sample\n" +
-                "current-context: test-sample\n" +
-                "kind: Config\n" +
-                "preferences: {}\n" +
-                "users: []", configDumpContent);
+                "current-context: test-sample\n"));
     }
 
     @Test


### PR DESCRIPTION
* Run tests for 1.16 and 1.17
* Drop tests for 1.10 and 1.11