### PR TITLE
Write kubeconfig back in the workspace

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
@@ -106,11 +106,6 @@ public class KubeConfigWriter {
      * @throws InterruptedException on file operations
      */
     public String writeKubeConfig() throws IOException, InterruptedException {
-        if (!workspace.exists()) {
-            launcher.getListener().getLogger().println("creating missing workspace to write kubeconfig");
-            workspace.mkdirs();
-        }
-
         // Lookup for the credentials on Jenkins
         final StandardCredentials credentials = CredentialsProvider.findCredentialById(credentialsId, StandardCredentials.class, build, Collections.emptyList());
         if (credentials == null) {
@@ -242,26 +237,11 @@ public class KubeConfigWriter {
     }
 
     private FilePath getTempKubeconfigFilePath() throws IOException, InterruptedException {
-        String tempFolder = workspace.getChannel().call(new ObtainTemporaryFolderCallable());
-        FilePath tempPath = new FilePath(workspace.getChannel(), tempFolder);
-        if (!tempPath.exists()) {
-            launcher.getListener().getLogger().println("creating missing temporary folder to write kube config files");
-            tempPath.mkdirs();
+        if (!workspace.exists()) {
+            launcher.getListener().getLogger().println("creating missing workspace to write kubeconfig");
+            workspace.mkdirs();
         }
 
-        return tempPath.createTempFile("kubernetes-cli-plugin-kube", "config");
+        return workspace.createTempFile(".kube","config");
     }
-
-    /**
-     * Used for obtaining the temporary folder for a node.
-     */
-    private static class ObtainTemporaryFolderCallable extends MasterToSlaveCallable<String, IOException> {
-        private static final String TMPDIR__PROPERTY = "java.io.tmpdir";
-
-        @Override
-        public String call() {
-            return System.getProperty(TMPDIR__PROPERTY);
-        }
-    }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapperTest.java
@@ -65,7 +65,7 @@ public class KubectlBuildWrapperTest {
         bw.serverUrl = "${SERVER_URL}";
         p.getBuildWrappersList().add(bw);
 
-        Shell b2 = new Shell("#!/bin/bash\ncat $KUBECONFIG");
+        Shell b2 = new Shell("#!/bin/bash\ncat \"$KUBECONFIG\"");
         p.getBuildersList().add(b2);
 
         FreeStyleBuild b = p.scheduleBuild2(0).waitForStart();


### PR DESCRIPTION
This write the `kubectl` credentials back into the workspace instead of the temporary folder of the agent, that might actually not always be available from the execution environment.

Workaround for https://github.com/jenkinsci/kubernetes-cli-plugin/issues/49
Effectively reverts https://github.com/jenkinsci/kubernetes-cli-plugin/commit/73e2e1aac46295d74795706ac7ba0b49e9b045b7