### PR TITLE
Fix raw kubeconfig context switch

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/GenericBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/GenericBuildStep.java
@@ -84,7 +84,7 @@ public class GenericBuildStep extends AbstractStepExecutionImpl {
             for(String configFile : configFiles) {
                 context.get(FilePath.class).child(configFile).delete();
             }
-            context.get(TaskListener.class).getLogger().println("kubectl configuration cleaned up");
+            context.get(TaskListener.class).getLogger().println("[kubernetes-cli] kubectl configuration cleaned up");
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/MultiKubectlBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/MultiKubectlBuildWrapper.java
@@ -92,7 +92,7 @@ public class MultiKubectlBuildWrapper extends SimpleBuildWrapper {
             for(String file : filesToBeRemoved) {
                 workspace.child(file).delete();
             }
-            listener.getLogger().println("kubectl configuration cleaned up");
+            listener.getLogger().println("[kubernetes-cli] kubectl configuration cleaned up");
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStepTest.java
@@ -66,7 +66,7 @@ public class KubectlBuildStepTest {
 
         assertNotNull(b);
         assertBuildStatus(b, Result.FAILURE);
-        r.assertLogContains("ERROR: Unable to find credentials with id 'test-credentials'", b);
+        r.assertLogContains("ERROR: [kubernetes-cli] unable to find credentials with id 'test-credentials'", b);
     }
 
     @Test
@@ -79,7 +79,7 @@ public class KubectlBuildStepTest {
 
         assertNotNull(b);
         assertBuildStatus(b, Result.FAILURE);
-        r.assertLogContains("kubectl configuration cleaned up", b);
+        r.assertLogContains("[kubernetes-cli] kubectl configuration cleaned up", b);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class KubectlBuildStepTest {
 
         assertNotNull(b);
         assertBuildStatus(b, Result.FAILURE);
-        r.assertLogContains("ERROR: Unable to find credentials with id ''", b);
+        r.assertLogContains("ERROR: [kubernetes-cli] unable to find credentials with id ''", b);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class KubectlBuildStepTest {
 
         assertNotNull(b);
         assertBuildStatus(b, Result.FAILURE);
-        r.assertLogContains("ERROR: Unsupported credentials type org.jenkinsci.plugins.kubernetes.cli.helpers.UnsupportedCredential", b);
+        r.assertLogContains("ERROR: [kubernetes-cli] unsupported credentials type org.jenkinsci.plugins.kubernetes.cli.helpers.UnsupportedCredential", b);
     }
 
     @Test


### PR DESCRIPTION
Fixes the handling of raw `kubeconfig` files and the switch to a context.
Since 1.8.0 the switch is done after settings the cluster up which doesn't make much sense and doesn't reflect what's in the documentation. Also and unrelated to this fix, this PR prefixes log lines with the name of the plugin, and add a warning if a user configures a context that does not exist in the `kubeconfig` file.

Fixes https://github.com/jenkinsci/kubernetes-cli-plugin/issues/51