### PR TITLE
add kubeconfig path test

### DIFF
--- a/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/withKubeConfigPipelineEchoPath.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/withKubeConfigPipelineEchoPath.groovy
@@ -1,7 +1,7 @@
 node{
   stage('Run') {
     withKubeConfig([credentialsId: 'test-credentials', serverUrl: 'https://localhost:6443']) {
-      echo "Using temporary file ${env.KUBECONFIG}"
+      echo "Using temporary file '${env.KUBECONFIG}'"
     }
   }
 }


### PR DESCRIPTION
adds an explicit test to verify the content of the `KUBECONFIG` variable and ensure there is no extra new line character at the end
see https://github.com/jenkinsci/kubernetes-cli-plugin/issues/64