### PR TITLE
enable tests on jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: true
 
 jdk:
   - openjdk8
+  - openjdk11
 
 cache:
   directories:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@ buildPlugin(
     platforms: ['windows'],
     timeout: 10,
     failFast: true,
-    jdkVersions: [8]
+    jdkVersions: [8, 11]
 )

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ node {
 ```
 
 ## Prerequisites
-* A jenkins installation running version 2.222.1 or higher.
+* A jenkins installation running version 2.222.1 or higher (with jdk8 or jdk11).
 * An executor with `kubectl` installed (tested against [v1.16 to v1.21][travis-config] included).
 * A Kubernetes cluster.
 


### PR DESCRIPTION
Support for Java 11 is coming:
* https://www.jenkins.io/doc/administration/requirements/upgrade-java-guidelines/
* https://www.jenkins.io/doc/administration/requirements/jenkins-on-java-11/