### PR TITLE
compile against kubernetes-client-api-5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+1.10.3
+-----
+* compile against kubernetes-client-api 5.4.1 [#86](https://github.com/jenkinsci/kubernetes-cli-plugin/pull/86)
+
 1.10.2
 -----
 * test with jdk11 [#83](https://github.com/jenkinsci/kubernetes-cli-plugin/pull/83)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ node {
 ```
 
 ## Prerequisites
-* A jenkins installation running version 2.222.1 or higher (with jdk8 or jdk11).
+* A jenkins installation running version 2.222.4 or higher (with jdk8 or jdk11).
 * An executor with `kubectl` installed (tested against [v1.16 to v1.21][travis-config] included).
 * A Kubernetes cluster.
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.2</version> <!-- or whatever the newest version available is -->
+    <version>4.18</version> <!-- or whatever the newest version available is -->
     <!--Check https://mvnrepository.com/artifact/org.jenkins-ci.plugins/plugin?repo=jenkins-releases-->
     <relativePath />
   </parent>
@@ -22,7 +22,7 @@
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
 
     <!-- dependency versions -->
-    <jenkins.version>2.222.1</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <bom.artifactId>bom-2.222.x</bom.artifactId>
     <bom.version>9</bom.version>
 
@@ -81,6 +81,17 @@
          <artifactId>authentication-tokens</artifactId>
          <version>1.3</version>
        </dependency>
+      <!-- required to enforce dependency version -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>kubernetes-client-api</artifactId>
+        <version>5.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>jackson2-api</artifactId>
+        <version>2.12.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The kubernetes plugin is bringing in kubernetes-client-api in version 5.4.1 which breaks kubernetes-cli.
This PR could fix kubernetes-cli until https://github.com/jenkinsci/kubernetes-credentials-plugin/pull/35 is merged