### PR TITLE
allow empty credentials for in-cluster Jenkins agents

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlCredential.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlCredential.java
@@ -53,12 +53,5 @@ public class KubectlCredential extends AbstractDescribableImpl<KubectlCredential
         public ListBoxModel doFillCredentialsIdItems(@Nonnull @AncestorInPath Item item, @QueryParameter String serverUrl, @QueryParameter String credentialsId) {
             return CredentialsLister.doFillCredentialsIdItems(item, serverUrl, credentialsId);
         }
-
-        public FormValidation doCheckCredentialsId(@QueryParameter String credentialsId) throws IOException, ServletException {
-            if (Strings.isNullOrEmpty(credentialsId)) {
-                return FormValidation.error("The credentialId cannot be empty");
-            }
-            return FormValidation.ok();
-        }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStepTest.java
@@ -90,8 +90,7 @@ public class KubectlBuildStepTest {
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
 
         assertNotNull(b);
-        assertBuildStatus(b, Result.FAILURE);
-        r.assertLogContains("ERROR: [kubernetes-cli] unable to find credentials with id ''", b);
+        assertBuildStatus(b, Result.SUCCESS);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterAuthTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterAuthTest.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.client.internal.SerializationUtils;
 import jenkins.security.ConfidentialStoreRule;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuth;
 import org.jenkinsci.plugins.kubernetes.auth.impl.*;
-import org.jenkinsci.plugins.kubernetes.cli.helpers.DummyCredentials;
 import org.jenkinsci.plugins.kubernetes.cli.helpers.DummyTokenCredentialImpl;
 import org.junit.Before;
 import org.junit.Rule;
@@ -75,7 +74,7 @@ public class KubeConfigWriterAuthTest {
 
         KubernetesAuth auth = new KubernetesAuthUsernamePassword("test-user", "test-password");
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         assertEquals("---\n" +
@@ -126,7 +125,7 @@ public class KubeConfigWriterAuthTest {
 
         KubernetesAuth auth = new KubernetesAuthCertificate(cert, key);
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         assertEquals("---\n" +
@@ -161,7 +160,7 @@ public class KubeConfigWriterAuthTest {
 
         KubernetesAuth auth = new KubernetesAuthToken(new DummyTokenCredentialImpl(CredentialsScope.GLOBAL, "test", "test", "test", "test"));
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         assertEquals("---\n" +
@@ -198,7 +197,7 @@ public class KubeConfigWriterAuthTest {
 
             KubernetesAuth auth = new KubernetesAuthKeystore(keyStore, "test");
 
-            ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+            ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
             String configDumpContent = dumpBuilder(configBuilder);
 
             assertEquals("---\n" +

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterBuilderTest.java
@@ -81,6 +81,75 @@ public class KubeConfigWriterBuilderTest {
     }
 
     @Test
+    public void inClusterServiceAccountToken() throws Exception {
+        KubeConfigWriter configWriter = new KubeConfigWriter(
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                workspace, mockLauncher, build);
+
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderInCluster();
+        String configDumpContent = dumpBuilder(configBuilder);
+
+        assertEquals("---\n" +
+                "clusters: []\n" +
+                "contexts: []\n" +
+                "current-context: \"k8s\"\n" +
+                "users: []\n", configDumpContent);
+    }
+
+    @Test
+    public void inClusterServiceAccountTokenWithNamespace() throws Exception {
+        KubeConfigWriter configWriter = new KubeConfigWriter(
+                "",
+                "",
+                "",
+                "",
+                "",
+                "test-namespace",
+                workspace, mockLauncher, build);
+
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderInCluster();
+        String configDumpContent = dumpBuilder(configBuilder);
+
+        assertEquals("---\n" +
+                "clusters: []\n" +
+                "contexts:\n" +
+                "- context:\n" +
+                "    namespace: \"test-namespace\"\n" +
+                "  name: \"k8s\"\n" +
+                "current-context: \"k8s\"\n" +
+                "users: []\n", configDumpContent);
+    }
+
+    @Test
+    public void inClusterServiceAccountTokeninClusterServiceAccountTokenWithContextAndNamespace() throws Exception {
+        KubeConfigWriter configWriter = new KubeConfigWriter(
+                "",
+                "",
+                "",
+                "",
+                "test-context",
+                "test-namespace",
+                workspace, mockLauncher, build);
+
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderInCluster();
+        String configDumpContent = dumpBuilder(configBuilder);
+
+        assertEquals("---\n" +
+                "clusters: []\n" +
+                "contexts:\n" +
+                "- context:\n" +
+                "    namespace: \"test-namespace\"\n" +
+                "  name: \"test-context\"\n" +
+                "current-context: \"test-context\"\n" +
+                "users: []\n", configDumpContent);
+    }
+
+    @Test
     public void basicConfigMinimum() throws Exception {
         KubeConfigWriter configWriter = new KubeConfigWriter(
                 "https://localhost:6443",
@@ -93,7 +162,7 @@ public class KubeConfigWriterBuilderTest {
 
         KubernetesAuth auth = new KubernetesAuthUsernamePassword("test-user", "test-password");
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         assertEquals("---\n" +
@@ -128,7 +197,7 @@ public class KubeConfigWriterBuilderTest {
 
         KubernetesAuth auth = new KubernetesAuthUsernamePassword("test-user", "test-password");
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         assertEquals("---\n" +
@@ -163,7 +232,7 @@ public class KubeConfigWriterBuilderTest {
 
         KubernetesAuth auth = new KubernetesAuthUsernamePassword("test-user", "test-password");
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         assertEquals("---\n" +
@@ -198,7 +267,7 @@ public class KubeConfigWriterBuilderTest {
 
         KubernetesAuth auth = new KubernetesAuthUsernamePassword("test-user", "test-password");
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         assertEquals("---\n" +
@@ -234,7 +303,7 @@ public class KubeConfigWriterBuilderTest {
 
         KubernetesAuth auth = new KubernetesAuthUsernamePassword("test-user", "test-password");
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         assertEquals("---\n" +
@@ -269,7 +338,7 @@ public class KubeConfigWriterBuilderTest {
 
         KubernetesAuthKubeconfig auth = dummyKubeConfigAuth();
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         // asserts that:
@@ -310,7 +379,7 @@ public class KubeConfigWriterBuilderTest {
 
         KubernetesAuthKubeconfig auth = dummyKubeConfigAuth();
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         // asserts that:
@@ -357,7 +426,7 @@ public class KubeConfigWriterBuilderTest {
 
         KubernetesAuthKubeconfig auth = dummyKubeConfigAuth();
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         // asserts that:
@@ -404,7 +473,7 @@ public class KubeConfigWriterBuilderTest {
 
         KubernetesAuthKubeconfig auth = dummyKubeConfigAuth();
 
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         // asserts that:
@@ -449,7 +518,7 @@ public class KubeConfigWriterBuilderTest {
                 workspace, mockLauncher, build);
 
         KubernetesAuthKubeconfig auth = dummyKubeConfigAuth();
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         // asserts that:
@@ -496,7 +565,7 @@ public class KubeConfigWriterBuilderTest {
                 workspace, mockLauncher, build);
 
         KubernetesAuthKubeconfig auth = dummyKubeConfigAuth();
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         // asserts that:
@@ -548,7 +617,7 @@ public class KubeConfigWriterBuilderTest {
                 workspace, mockLauncher, build);
 
         KubernetesAuthKubeconfig auth = dummyKubeConfigAuth();
-        ConfigBuilder configBuilder = configWriter.getConfigBuilder("test-credential", auth);
+        ConfigBuilder configBuilder = configWriter.getConfigBuilderWithAuth("test-credential", auth);
         String configDumpContent = dumpBuilder(configBuilder);
 
         assertEquals("---\n" +

--- a/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/withKubeConfigPipelineMissingCredentials.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/withKubeConfigPipelineMissingCredentials.groovy
@@ -1,8 +1,8 @@
 node{
   label "mocked-kubectl"
   stage('Run') {
-    withKubeConfig([credentialsId: '', serverUrl: 'https://localhost:6443']) {
-      echo "This should never be displayed as the plugin should fail"
+    withKubeConfig() {
+      echo "example when running inside a Pod with a ServiceAccount tokens"
     }
   }
 }


### PR DESCRIPTION
This PR allows the Kubernetes CLI Plugin to have `kubectl` fall back to a Pod's ServiceAccount, when the pipelines run inside Kubernetes.

The (kubernetes-credentials-plugin)[https://github.com/jenkinsci/kubernetes-credentials-plugin] provides a dedicated ServiceAccount kind of credentials but hose will soon not be usable anymore. Kubernetes has introduced rotation for those ServiceAccount token, and it appears that some service provider set a rather rotation lifetime (compared to previous infinity).

See:
* https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.21
* https://issues.jenkins.io/browse/JENKINS-68584
* https://issues.jenkins.io/browse/JENKINS-68557