### PR TITLE
Upgrade kubernetes-client to 6.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>kubernetes-client-api</artifactId>
-        <version>6.3.1-204.v5400f87efd3c</version>
+        <version>6.3.1-206.v76d3b_6b_14db_b</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <!-- jenkins plugins versions -->
     <jenkins-env-inject.version>2.3.0</jenkins-env-inject.version>
     <jenkins-declarative.version>1.4.0</jenkins-declarative.version>
-    <jenkins-kubernetes-credentials.version>0.9.1-rc136.6105f8f63f7f</jenkins-kubernetes-credentials.version>
+    <jenkins-kubernetes-credentials.version>0.10.0</jenkins-kubernetes-credentials.version>
 
     <!-- maven plugins versions -->
     <maven-coveralls.version>4.3.0</maven-coveralls.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.18</version> <!-- or whatever the newest version available is -->
-    <!--Check https://mvnrepository.com/artifact/org.jenkins-ci.plugins/plugin?repo=jenkins-releases-->
+    <version>4.50</version>
     <relativePath />
   </parent>
 
@@ -22,14 +21,14 @@
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
 
     <!-- dependency versions -->
-    <jenkins.version>2.222.4</jenkins.version>
-    <bom.artifactId>bom-2.222.x</bom.artifactId>
-    <bom.version>9</bom.version>
+    <jenkins.version>2.332.4</jenkins.version>
+    <bom.artifactId>bom-2.332.x</bom.artifactId>
+    <bom.version>1763.v092b_8980a_f5e</bom.version>
 
     <!-- jenkins plugins versions -->
     <jenkins-env-inject.version>2.3.0</jenkins-env-inject.version>
     <jenkins-declarative.version>1.4.0</jenkins-declarative.version>
-    <jenkins-kubernetes-credentials.version>0.9.0</jenkins-kubernetes-credentials.version>
+    <jenkins-kubernetes-credentials.version>0.9.1-rc136.6105f8f63f7f</jenkins-kubernetes-credentials.version>
 
     <!-- maven plugins versions -->
     <maven-coveralls.version>4.3.0</maven-coveralls.version>
@@ -85,12 +84,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>kubernetes-client-api</artifactId>
-        <version>5.4.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>jackson2-api</artifactId>
-        <version>2.12.3</version>
+        <version>6.3.1-204.v5400f87efd3c</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -160,13 +154,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.28</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.0.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriter.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.kubernetes.cli.kubeconfig;
 
+import io.fabric8.kubernetes.client.utils.Serialization;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -24,7 +25,6 @@ import io.fabric8.kubernetes.api.model.Cluster;
 import io.fabric8.kubernetes.api.model.ConfigBuilder;
 import io.fabric8.kubernetes.api.model.ConfigFluent;
 import io.fabric8.kubernetes.api.model.NamedCluster;
-import io.fabric8.kubernetes.client.internal.SerializationUtils;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
 
 /**
@@ -81,7 +81,7 @@ public class KubeConfigWriter {
     }
 
     private static ConfigBuilder setCurrentContext(ConfigBuilder configBuilder, String context) {
-        return configBuilder.withNewCurrentContext(context);
+        return configBuilder.withCurrentContext(context);
     }
 
     private static ConfigFluent.ContextsNested<ConfigBuilder> existingOrNewContext(ConfigBuilder configBuilder,
@@ -138,7 +138,7 @@ public class KubeConfigWriter {
 
         // Write configuration to disk
         FilePath configFile = getTempKubeconfigFilePath();
-        configFile.write(SerializationUtils.getMapper().writeValueAsString(configBuilder.build()),
+        configFile.write(Serialization.asYaml(configBuilder.build()),
                 String.valueOf(StandardCharsets.UTF_8));
         if (restrictKubeConfigAccess != null && restrictKubeConfigAccess) {
             configFile.chmod(0600);

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/helpers/Version.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/helpers/Version.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.kubernetes.cli.helpers;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /*
  From https://gist.github.com/brianguertin/ada4b65c6d1c4f6d3eee3c12b6ce021b

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterAuthTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterAuthTest.java
@@ -9,7 +9,7 @@ import hudson.model.AbstractBuild;
 import hudson.remoting.VirtualChannel;
 import hudson.util.SecretRule;
 import io.fabric8.kubernetes.api.model.ConfigBuilder;
-import io.fabric8.kubernetes.client.internal.SerializationUtils;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import jenkins.security.ConfidentialStoreRule;
 import org.jenkinsci.plugins.kubernetes.auth.KubernetesAuth;
 import org.jenkinsci.plugins.kubernetes.auth.impl.*;
@@ -52,7 +52,7 @@ public class KubeConfigWriterAuthTest {
     AbstractBuild build;
 
     private static String dumpBuilder(ConfigBuilder configBuilder) throws JsonProcessingException {
-        return SerializationUtils.getMapper().writeValueAsString(configBuilder.build());
+        return Serialization.asYaml(configBuilder.build());
     }
 
     private static KeyStore loadKeyStore(InputStream inputStream, char[] password) throws CertificateException, NoSuchAlgorithmException, IOException, KeyStoreException {

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterBuilderTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import io.fabric8.kubernetes.client.utils.Serialization;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -26,7 +27,6 @@ import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import io.fabric8.kubernetes.api.model.ConfigBuilder;
-import io.fabric8.kubernetes.client.internal.SerializationUtils;
 
 public class KubeConfigWriterBuilderTest {
     final ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -37,7 +37,7 @@ public class KubeConfigWriterBuilderTest {
     AbstractBuild build;
 
     private static String dumpBuilder(ConfigBuilder configBuilder) throws JsonProcessingException {
-        return SerializationUtils.getMapper().writeValueAsString(configBuilder.build());
+        return Serialization.asYaml(configBuilder.build());
     }
 
     private static KubernetesAuthKubeconfig dummyKubeConfigAuth() {

--- a/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/withKubeConfigPipelineConfigDump.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/kubernetes/cli/withKubeConfigPipelineConfigDump.groovy
@@ -3,9 +3,9 @@ node{
   stage('Run') {
     withKubeConfig([credentialsId: 'test-credentials', serverUrl: 'https://localhost:6443']) {
       if (isUnix()) {
-        sh 'kubectl config view > configDump'
+        sh 'kubectl config view --raw > configDump'
       }else{
-        bat 'kubectl.exe config view > configDump'
+        bat 'kubectl.exe config view --raw > configDump'
       }
     }
   }


### PR DESCRIPTION
This makes this plugin compatible with newer kubernetes-client version.

Downstream of 

* https://github.com/jenkinsci/kubernetes-client-api-plugin/pull/163
* https://github.com/jenkinsci/kubernetes-credentials-plugin/pull/36

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
