### PR TITLE
upgrade docker-commons to 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>docker-commons</artifactId>
-      <version>1.15</version>
+      <version>1.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
We're pulling the dependency for testing, and versions under 1.17 have some vulnerabilities:
> Jenkins Docker Commons Plugin 1.17 and earlier does not sanitize the name of an image or a tag, resulting in an OS command execution vulnerability exploitable by attackers with Item/Configure permission or able to control the contents of a previously configured job's SCM repository.