### PR TITLE
don't build for Java 8 anymore

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 // Java versions to test against
-String[] jdkVersions = [8, 11]
+String[] unitTestJdkVersions = [11]
+String integrationJdkVersions = 11
 
 // Platform to test for
 String[] platforms = [
@@ -52,7 +53,7 @@ def unitTest(platform, jdk) {
                 checkout scm
             }
             stage('tests') {
-                infra.runWithJava('mvn clean -Dgroups="! org.jenkinsci.plugins.kubernetes.cli.KubectlIntegrationTest" test findbugs:check', jdk)
+                infra.runWithJava('mvn clean -Dgroups="! org.jenkinsci.plugins.kubernetes.cli.KubectlIntegrationTest" test spotbugs:check', jdk)
             }
             // stage('coverage') {
             //     infra.runWithJava('mvn jacoco:report coveralls:report')
@@ -91,15 +92,15 @@ for (int i = 0; i < kubectlVersions.size(); i++) {
 
         def stepName = "integration/${platform}/v${kubectlVersion}"
         stepsForParallel[stepName] = { ->
-            integrationTest(platform, jdkVersions[1], kubectlVersion)
+            integrationTest(platform, integrationJdkVersions, kubectlVersion)
         }
     }
 }
 for (int j = 0; j < platforms.size(); j++) {
     def platform = platforms[j]
 
-    for (int k = 0; k < jdkVersions.size(); k++) {
-    def jdkVersion = jdkVersions[k]
+    for (int k = 0; k < unitTestJdkVersions.size(); k++) {
+    def jdkVersion = unitTestJdkVersions[k]
         def stepName = "unit/${platform}/${jdkVersion}"
         stepsForParallel[stepName] = { ->
             unitTest(platform, jdkVersion)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.50</version>
+    <version>4.54</version>
     <relativePath />
   </parent>
 
@@ -17,13 +17,12 @@
   <properties>
     <revision>1.11.1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <java.level>8</java.level>
     <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
 
     <!-- dependency versions -->
-    <jenkins.version>2.332.4</jenkins.version>
-    <bom.artifactId>bom-2.332.x</bom.artifactId>
-    <bom.version>1763.v092b_8980a_f5e</bom.version>
+    <jenkins.version>2.361.4</jenkins.version>
+    <bom.artifactId>bom-2.361.x</bom.artifactId>
+    <bom.version>1798.vc671fe94856f</bom.version>
 
     <!-- jenkins plugins versions -->
     <jenkins-env-inject.version>2.3.0</jenkins-env-inject.version>

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapperTest.java
@@ -143,7 +143,7 @@ public class KubectlBuildWrapperTest {
         as.add(Jenkins.READ, "user-not-enough-permissions");
         r.jenkins.setAuthorizationStrategy(as);
 
-        try (ACLContext _ = ACL.as(User.get("user-not-enough-permissions", true, null).impersonate())) {
+        try (ACLContext unused = ACL.as(User.get("user-not-enough-permissions", true, null).impersonate())) {
             ListBoxModel options = d.doFillCredentialsIdItems(null, "", "1");
             assertEquals("- current -", options.get(0).name);
             assertEquals(1, options.size());


### PR DESCRIPTION
The Jenkins community is moving to Java 11: https://www.jenkins.io/blog/2022/12/14/require-java-11/