### PR TITLE
run units with java 11 and 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // Java versions to test against
-String[] unitTestJdkVersions = [11]
+String[] unitTestJdkVersions = [11, 17]
 String integrationJdkVersions = 11
 
 // Platform to test for


### PR DESCRIPTION
The Jenkins community already moved to Java 11, and preparation are required for Java 17: https://www.jenkins.io/blog/2022/12/14/require-java-11/