### PR TITLE
requirePOST on doFillCredentialsIdItems

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/CredentialsLister.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/CredentialsLister.java
@@ -13,6 +13,7 @@ import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import hudson.model.Item;
 import hudson.security.ACL;
@@ -29,6 +30,7 @@ public abstract class CredentialsLister {
             CredentialsMatchers.instanceOf(StandardCertificateCredentials.class),
             CredentialsMatchers.instanceOf(FileCredentials.class));
 
+    @RequirePOST
     public static ListBoxModel doFillCredentialsIdItems(@NonNull @AncestorInPath Item item,
             @QueryParameter String serverUrl, @QueryParameter String credentialsId) {
         if (item == null

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
@@ -13,6 +13,8 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
@@ -95,6 +97,7 @@ public class KubectlBuildStep extends Step {
             return new HashSet<>();
         }
 
+        @RequirePOST
         public ListBoxModel doFillCredentialsIdItems(@NonNull @AncestorInPath Item item,
                 @QueryParameter String serverUrl, @QueryParameter String credentialsId) {
             return CredentialsLister.doFillCredentialsIdItems(item, serverUrl, credentialsId);

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper.java
@@ -8,6 +8,8 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -85,6 +87,7 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
             return "Configure Kubernetes CLI (kubectl) (deprecated, use the multi credentials one instead)";
         }
 
+        @RequirePOST
         public ListBoxModel doFillCredentialsIdItems(@NonNull @AncestorInPath Item item,
                 @QueryParameter String serverUrl, @QueryParameter String credentialsId) {
             return CredentialsLister.doFillCredentialsIdItems(item, serverUrl, credentialsId);

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlCredential.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlCredential.java
@@ -4,6 +4,8 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
@@ -45,6 +47,7 @@ public class KubectlCredential extends AbstractDescribableImpl<KubectlCredential
             return "";
         }
 
+        @RequirePOST
         public ListBoxModel doFillCredentialsIdItems(@NonNull @AncestorInPath Item item,
                 @QueryParameter String serverUrl, @QueryParameter String credentialsId) {
             return CredentialsLister.doFillCredentialsIdItems(item, serverUrl, credentialsId);


### PR DESCRIPTION
The Jenkins project recommends requiring HTTP POSTs on method that have side effects, or can harm the server when hammered, which perfectly makes sense. The security scanner issues warnings for the `doFillCredentialsIdItems` methods which are used to fill the credential list in the UI.

I don't expect the code being called to have any side-effect, but I see the community has adopted a mixed-posture for very similar code, oscillating between ignoring the security warning, or switching to POST. Better safe than sorry: requiring a POST is unlikely to cause any problem, let's just do it even if it's not necessary.